### PR TITLE
Add auth module unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ jacoco {
 
 jacocoTestReport {
     reports {
-        xml.required = false
+        xml.required = true
         csv.required = false
         html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
     }

--- a/src/test/java/com/hab/blog/auth/UserServiceTest.java
+++ b/src/test/java/com/hab/blog/auth/UserServiceTest.java
@@ -1,0 +1,83 @@
+import com.hab.blog.api.v1.auth.Entity.User;
+import com.hab.blog.api.v1.auth.UserRepository;
+import com.hab.blog.api.v1.auth.VerificationTokenRepository;
+import com.hab.blog.api.v1.auth.Service.UserService;
+import com.hab.blog.api.v1.Objective.dto.UserRegistrationDto;
+import com.hab.blog.api.v1.response.exception.AlreadyExistsException;
+import com.hab.blog.api.v1.response.exception.MailException;
+import com.hab.blog.api.v1.service.EmailService;
+import com.hab.blog.api.v1.service.RoleService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @Mock
+    private EmailService emailService;
+    @Mock
+    private RoleService roleService;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private VerificationTokenRepository verificationTokenRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    private UserRegistrationDto dto;
+
+    @BeforeEach
+    void setup() {
+        dto = new UserRegistrationDto();
+        dto.setUserName("tester");
+        dto.setAvatar("avatar");
+        dto.setEmail("test@example.com");
+        dto.setPassword("password");
+    }
+
+    @Test
+    void createUser_savesUserAndToken() throws Exception {
+        when(userRepository.existsByUserName(dto.getUserName())).thenReturn(false);
+        when(userRepository.existsByEmail(dto.getEmail())).thenReturn(false);
+
+        User saved = new User();
+        saved.setId(1L);
+        when(userRepository.save(any(User.class))).thenReturn(saved);
+
+        User result = userService.createUser(dto);
+
+        assertThat(result).isEqualTo(saved);
+        verify(userRepository).save(any(User.class));
+        verify(verificationTokenRepository).save(any());
+        verify(emailService).sendActivationEmail(eq(dto.getEmail()), eq(dto.getUserName()), anyString());
+    }
+
+    @Test
+    void createUser_whenUsernameExists_throwException() {
+        when(userRepository.existsByUserName(dto.getUserName())).thenReturn(true);
+        assertThatThrownBy(() -> userService.createUser(dto))
+                .isInstanceOf(AlreadyExistsException.class);
+    }
+
+    @Test
+    void createUser_whenEmailExists_throwException() {
+        when(userRepository.existsByEmail(dto.getEmail())).thenReturn(true);
+        when(userRepository.existsByUserName(dto.getUserName())).thenReturn(false);
+        assertThatThrownBy(() -> userService.createUser(dto))
+                .isInstanceOf(MailException.class);
+    }
+
+    @Test
+    void generateNewToken_returnsSixDigitString() {
+        String token = userService.generateNewToken();
+        assertThat(token).hasSize(6).matches("\\d{6}");
+    }
+}

--- a/src/test/java/com/hab/blog/framework/enums/CommonStatusEnumTest.java
+++ b/src/test/java/com/hab/blog/framework/enums/CommonStatusEnumTest.java
@@ -1,0 +1,19 @@
+import com.hab.blog.api.v1.framework.common.enums.CommonStatusEnum;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommonStatusEnumTest {
+
+    @Test
+    void array_containsAllStatuses() {
+        int[] array = CommonStatusEnum.ENABLE.array();
+        assertThat(array).containsExactlyInAnyOrder(0, 1);
+    }
+
+    @Test
+    void isEnable_and_isDisable_workCorrectly() {
+        assertThat(CommonStatusEnum.isEnable(0)).isTrue();
+        assertThat(CommonStatusEnum.isDisable(0)).isFalse();
+        assertThat(CommonStatusEnum.isDisable(1)).isTrue();
+    }
+}

--- a/src/test/java/com/hab/blog/moods/MoodServiceTest.java
+++ b/src/test/java/com/hab/blog/moods/MoodServiceTest.java
@@ -1,0 +1,83 @@
+import com.hab.blog.api.v1.auth.Entity.User;
+import com.hab.blog.api.v1.auth.UserRepository;
+import com.hab.blog.api.v1.moods.Entity.Mood;
+import com.hab.blog.api.v1.moods.Repository.MoodRepository;
+import com.hab.blog.api.v1.moods.Service.MoodService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class MoodServiceTest {
+
+    @Mock
+    private MoodRepository moodRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private MoodService moodService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setId(1L);
+    }
+
+    @Test
+    void createMood_shouldSaveAndReturnMood() {
+        LocalDate date = LocalDate.now();
+        int level = 3;
+        Mood mood = new Mood();
+        mood.setUser(user);
+        mood.setDate(date);
+        mood.setMoodLevel(level);
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(moodRepository.save(any(Mood.class))).thenReturn(mood);
+
+        Mood result = moodService.createMood(user.getId(), date, level);
+
+        assertThat(result.getUser()).isEqualTo(user);
+        assertThat(result.getDate()).isEqualTo(date);
+        assertThat(result.getMoodLevel()).isEqualTo(level);
+        verify(moodRepository).save(any(Mood.class));
+    }
+
+    @Test
+    void updateMood_shouldUpdateExistingRecord() {
+        LocalDate date = LocalDate.now();
+        Mood existing = new Mood();
+        existing.setUser(user);
+        existing.setDate(date);
+        existing.setMoodLevel(1);
+        when(moodRepository.findByUserIdAndDate(user.getId(), date)).thenReturn(Optional.of(existing));
+        when(moodRepository.save(existing)).thenReturn(existing);
+
+        Mood result = moodService.updateMood(user.getId(), date, 5);
+
+        assertThat(result.getMoodLevel()).isEqualTo(5);
+        verify(moodRepository).save(existing);
+    }
+
+    @Test
+    void updateMood_shouldThrowIfNotFound() {
+        when(moodRepository.findByUserIdAndDate(anyLong(), any(LocalDate.class))).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> moodService.updateMood(1L, LocalDate.now(), 2));
+    }
+}


### PR DESCRIPTION
## Summary
- enable XML generation for jacoco test report
- test `UserService` covering happy path and failure conditions

## Testing
- `./gradlew build --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6854e87f3880832bbd6371e5cbddd9e7