### PR TITLE
Add auth module unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ jacoco {
 
 jacocoTestReport {
     reports {
-        xml.required = false
+        xml.required = true
         csv.required = false
         html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
     }
@@ -91,6 +91,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.21.0'
     testImplementation 'org.mockito:mockito-core:4.0.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:4.0.0'
+    testImplementation 'org.mockito:mockito-inline:4.0.0'
     testImplementation 'org.springframework:spring-messaging'
 }
 

--- a/src/test/java/com/hab/blog/auth/AuthControllerTest.java
+++ b/src/test/java/com/hab/blog/auth/AuthControllerTest.java
@@ -1,0 +1,95 @@
+import com.hab.blog.api.v1.Objective.dto.JwtRequestDto;
+import com.hab.blog.api.v1.Objective.dto.UserRegistrationDto;
+import com.hab.blog.api.v1.auth.AuthController;
+import com.hab.blog.api.v1.auth.Entity.User;
+import com.hab.blog.api.v1.auth.Entity.VerificationRequest;
+import com.hab.blog.api.v1.auth.Entity.VerificationToken;
+import com.hab.blog.api.v1.auth.Service.UserService;
+import com.hab.blog.api.v1.response.ApiResponse;
+import com.hab.blog.api.v1.response.exception.AlreadyExistsException;
+import com.hab.blog.api.v1.utility.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthControllerTest {
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private AuthController controller;
+
+    @BeforeEach
+    void setup() {
+        // fields are injected via Mockito @InjectMocks, but ensure
+        ReflectionTestUtils.setField(controller, "authenticationManager", authenticationManager);
+        ReflectionTestUtils.setField(controller, "jwtTokenProvider", jwtTokenProvider);
+        ReflectionTestUtils.setField(controller, "userService", userService);
+    }
+
+    @Test
+    void createAuthenticationToken_returnsToken() throws Exception {
+        JwtRequestDto dto = new JwtRequestDto();
+        dto.setEmail("test@example.com");
+        dto.setPassword("pass");
+        User user = new User();
+        user.setUserName("tester");
+        when(userService.findUsersByEmail(dto.getEmail())).thenReturn(Optional.of(user));
+        Authentication auth = mock(Authentication.class);
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).thenReturn(auth);
+        when(jwtTokenProvider.createToken(auth)).thenReturn("jwt");
+
+        ResponseEntity<?> response = controller.createAuthenticationToken(dto);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        assertThat(body.getData()).isEqualTo("jwt");
+    }
+
+    @Test
+    void registerUser_returnsConflictWhenExists() throws Exception {
+        UserRegistrationDto dto = new UserRegistrationDto();
+        doThrow(new AlreadyExistsException("User", "username", "u")).when(userService).createUser(dto);
+
+        ResponseEntity<ApiResponse<String>> response = controller.registerUser(dto);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    void confirmRegistration_success() {
+        VerificationRequest request = new VerificationRequest();
+        request.setToken("tok");
+        request.setUserId(1L);
+        User user = new User();
+        VerificationToken token = new VerificationToken("tok", VerificationToken.TokenType.VERIFY_EMAIL, "e", 1L);
+
+        when(userService.findById(1L)).thenReturn(Optional.of(user));
+        when(userService.findByUserIdAndToken("tok", 1L)).thenReturn(Optional.of(token));
+        ResponseEntity<?> response = controller.confirmRegistration(request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        verify(userService).updateUser(user);
+        verify(userService).deleteVerificationToken(token);
+    }
+}

--- a/src/test/java/com/hab/blog/auth/UserServiceTest.java
+++ b/src/test/java/com/hab/blog/auth/UserServiceTest.java
@@ -1,0 +1,109 @@
+import com.hab.blog.api.v1.auth.Entity.User;
+import com.hab.blog.api.v1.auth.UserRepository;
+import com.hab.blog.api.v1.auth.VerificationTokenRepository;
+import com.hab.blog.api.v1.auth.Service.UserService;
+import com.hab.blog.api.v1.Objective.dto.UserRegistrationDto;
+import com.hab.blog.api.v1.response.exception.AlreadyExistsException;
+import com.hab.blog.api.v1.response.exception.MailException;
+import com.hab.blog.api.v1.service.EmailService;
+import com.hab.blog.api.v1.service.RoleService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @Mock
+    private EmailService emailService;
+    @Mock
+    private RoleService roleService;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private VerificationTokenRepository verificationTokenRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    private UserRegistrationDto dto;
+
+    @BeforeEach
+    void setup() {
+        dto = new UserRegistrationDto();
+        dto.setUserName("tester");
+        dto.setAvatar("avatar");
+        dto.setEmail("test@example.com");
+        dto.setPassword("password");
+    }
+
+    @Test
+    void createUser_savesUserAndToken() throws Exception {
+        when(userRepository.existsByUserName(dto.getUserName())).thenReturn(false);
+        when(userRepository.existsByEmail(dto.getEmail())).thenReturn(false);
+
+        User saved = new User();
+        saved.setId(1L);
+        when(userRepository.save(any(User.class))).thenReturn(saved);
+
+        User result = userService.createUser(dto);
+
+        assertThat(result).isEqualTo(saved);
+        verify(userRepository).save(any(User.class));
+        verify(verificationTokenRepository).save(any());
+        verify(emailService).sendActivationEmail(eq(dto.getEmail()), eq(dto.getUserName()), anyString());
+    }
+
+    @Test
+    void createUser_whenUsernameExists_throwException() {
+        when(userRepository.existsByUserName(dto.getUserName())).thenReturn(true);
+        assertThatThrownBy(() -> userService.createUser(dto))
+                .isInstanceOf(AlreadyExistsException.class);
+    }
+
+    @Test
+    void createUser_whenEmailExists_throwException() {
+        when(userRepository.existsByEmail(dto.getEmail())).thenReturn(true);
+        when(userRepository.existsByUserName(dto.getUserName())).thenReturn(false);
+        assertThatThrownBy(() -> userService.createUser(dto))
+                .isInstanceOf(MailException.class);
+    }
+
+    @Test
+    void generateNewToken_returnsSixDigitString() {
+        String token = userService.generateNewToken();
+        assertThat(token).hasSize(6).matches("\\d{6}");
+    }
+
+    @Test
+    void resetUserPassword_savesToken() {
+        User user = new User();
+        user.setEmail("e@e.com");
+        user.setUserName("name");
+        userService.resetUserPassword(user);
+        verify(verificationTokenRepository).save(any());
+        verify(emailService).sendReSetPassword(eq("e@e.com"), eq("name"), anyString());
+    }
+
+    @Test
+    void loadUserByUsername_returnsUserDetails() {
+        User user = new User();
+        user.setUserName("name");
+        user.setPassword("pwd");
+        when(userRepository.findByUserNameWithRoles("name")).thenReturn(Optional.of(user));
+
+        UserDetails details = userService.loadUserByUsername("name");
+
+        assertThat(details.getUsername()).isEqualTo("name");
+        assertThat(details.getPassword()).isEqualTo("pwd");
+    }
+}

--- a/src/test/java/com/hab/blog/auth/VerificationTokenTest.java
+++ b/src/test/java/com/hab/blog/auth/VerificationTokenTest.java
@@ -1,0 +1,25 @@
+import com.hab.blog.api.v1.auth.Entity.VerificationToken;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VerificationTokenTest {
+
+    @Test
+    void isExpired_returnsTrueWhenExpiryDatePast() {
+        VerificationToken token = new VerificationToken("t", VerificationToken.TokenType.VERIFY_EMAIL, "e", 1L);
+        ReflectionTestUtils.setField(token, "expiryDate", Instant.now().minusSeconds(60));
+        assertThat(token.isExpired()).isTrue();
+    }
+
+    @Test
+    void constructor_setsFutureExpiryDate() {
+        VerificationToken token = new VerificationToken("t", VerificationToken.TokenType.RESET_PASSWORD, "e", 1L);
+        assertThat(token.getExpiryDate()).isAfter(Instant.now());
+        assertThat(token.getToken()).isEqualTo("t");
+        assertThat(token.getTokenType()).isEqualTo(VerificationToken.TokenType.RESET_PASSWORD);
+    }
+}

--- a/src/test/java/com/hab/blog/auth/WeChatAuthServiceTest.java
+++ b/src/test/java/com/hab/blog/auth/WeChatAuthServiceTest.java
@@ -1,0 +1,70 @@
+import com.hab.blog.api.v1.auth.Entity.User;
+import com.hab.blog.api.v1.auth.Entity.WeChatLoginResponse;
+import com.hab.blog.api.v1.auth.Service.WeChatAuthService;
+import com.hab.blog.api.v1.auth.UserRepository;
+import com.hab.blog.api.v1.response.ApiResponse;
+import com.hab.blog.api.v1.utility.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class WeChatAuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    private WeChatAuthService authService;
+
+    @BeforeEach
+    void setup() {
+        ReflectionTestUtils.setField(authService, "appId", "id");
+        ReflectionTestUtils.setField(authService, "appSecret", "secret");
+    }
+
+    @Test
+    void loginWithWeChat_createsUserWhenNotFound() {
+        WeChatLoginResponse response = new WeChatLoginResponse();
+        response.setOpenid("openid");
+        try (MockedConstruction<RestTemplate> mocked = mockConstruction(RestTemplate.class,
+            (mock, ctx) -> when(mock.getForObject(anyString(), eq(WeChatLoginResponse.class))).thenReturn(response))) {
+            when(userRepository.findByOpenid("openid")).thenReturn(Optional.empty());
+            when(jwtTokenProvider.createToken(any(UsernamePasswordAuthenticationToken.class))).thenReturn("token");
+
+            ApiResponse<String> result = authService.loginWithWeChat("code");
+
+            assertThat(result.getData()).isEqualTo("token");
+            verify(userRepository).save(any(User.class));
+        }
+    }
+
+    @Test
+    void loginWithWeChat_throwsWhenErrorReturned() {
+        WeChatLoginResponse response = new WeChatLoginResponse();
+        response.setErrcode(1);
+        response.setErrmsg("error");
+        try (MockedConstruction<RestTemplate> mocked = mockConstruction(RestTemplate.class,
+            (mock, ctx) -> when(mock.getForObject(anyString(), eq(WeChatLoginResponse.class))).thenReturn(response))) {
+            assertThatThrownBy(() -> authService.loginWithWeChat("code"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("微信登录失败");
+        }
+    }
+}

--- a/src/test/java/com/hab/blog/framework/enums/CommonStatusEnumTest.java
+++ b/src/test/java/com/hab/blog/framework/enums/CommonStatusEnumTest.java
@@ -1,0 +1,19 @@
+import com.hab.blog.api.v1.framework.common.enums.CommonStatusEnum;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommonStatusEnumTest {
+
+    @Test
+    void array_containsAllStatuses() {
+        int[] array = CommonStatusEnum.ENABLE.array();
+        assertThat(array).containsExactlyInAnyOrder(0, 1);
+    }
+
+    @Test
+    void isEnable_and_isDisable_workCorrectly() {
+        assertThat(CommonStatusEnum.isEnable(0)).isTrue();
+        assertThat(CommonStatusEnum.isDisable(0)).isFalse();
+        assertThat(CommonStatusEnum.isDisable(1)).isTrue();
+    }
+}

--- a/src/test/java/com/hab/blog/moods/MoodServiceTest.java
+++ b/src/test/java/com/hab/blog/moods/MoodServiceTest.java
@@ -1,0 +1,83 @@
+import com.hab.blog.api.v1.auth.Entity.User;
+import com.hab.blog.api.v1.auth.UserRepository;
+import com.hab.blog.api.v1.moods.Entity.Mood;
+import com.hab.blog.api.v1.moods.Repository.MoodRepository;
+import com.hab.blog.api.v1.moods.Service.MoodService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class MoodServiceTest {
+
+    @Mock
+    private MoodRepository moodRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private MoodService moodService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setId(1L);
+    }
+
+    @Test
+    void createMood_shouldSaveAndReturnMood() {
+        LocalDate date = LocalDate.now();
+        int level = 3;
+        Mood mood = new Mood();
+        mood.setUser(user);
+        mood.setDate(date);
+        mood.setMoodLevel(level);
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(moodRepository.save(any(Mood.class))).thenReturn(mood);
+
+        Mood result = moodService.createMood(user.getId(), date, level);
+
+        assertThat(result.getUser()).isEqualTo(user);
+        assertThat(result.getDate()).isEqualTo(date);
+        assertThat(result.getMoodLevel()).isEqualTo(level);
+        verify(moodRepository).save(any(Mood.class));
+    }
+
+    @Test
+    void updateMood_shouldUpdateExistingRecord() {
+        LocalDate date = LocalDate.now();
+        Mood existing = new Mood();
+        existing.setUser(user);
+        existing.setDate(date);
+        existing.setMoodLevel(1);
+        when(moodRepository.findByUserIdAndDate(user.getId(), date)).thenReturn(Optional.of(existing));
+        when(moodRepository.save(existing)).thenReturn(existing);
+
+        Mood result = moodService.updateMood(user.getId(), date, 5);
+
+        assertThat(result.getMoodLevel()).isEqualTo(5);
+        verify(moodRepository).save(existing);
+    }
+
+    @Test
+    void updateMood_shouldThrowIfNotFound() {
+        when(moodRepository.findByUserIdAndDate(anyLong(), any(LocalDate.class))).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> moodService.updateMood(1L, LocalDate.now(), 2));
+    }
+}


### PR DESCRIPTION
## Summary
- enable XML generation for jacoco test report
- test `UserService` covering happy path and failure conditions
- add unit tests for AuthController, WeChatAuthService, and VerificationToken
- extend UserService tests for password reset and user details
- include mockito-inline to allow constructor mocking

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6854e87f3880832bbd6371e5cbddd9e7